### PR TITLE
New demos & API additions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambda_rs_minimal"
+version = "0.1.0"
+dependencies = [
+ "lambda",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,7 +140,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object 0.27.1",
  "rustc-demangle",
 ]
@@ -173,6 +179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
+name = "bytemuck"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,12 +192,15 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "calloop"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82"
+checksum = "a22a6a8f622f797120d452c630b0ab12e1331a1a753e2039ce7868d4ac77b4ee"
 dependencies = [
  "log",
- "nix 0.22.3",
+ "nix 0.24.2",
+ "slotmap 1.0.6",
+ "thiserror",
+ "vec_map",
 ]
 
 [[package]]
@@ -360,9 +375,9 @@ dependencies = [
  "bitflags",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.2",
- "core-graphics 0.22.3",
- "foreign-types",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -375,9 +390,9 @@ checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation 0.9.2",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -401,29 +416,13 @@ checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
 dependencies = [
- "core-foundation-sys 0.8.3",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -433,26 +432,14 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "core-graphics"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
-dependencies = [
- "bitflags",
- "core-foundation 0.7.0",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.2",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -463,22 +450,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.2",
- "foreign-types",
+ "core-foundation",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
 [[package]]
-name = "core-video-sys"
-version = "0.1.4"
+name = "core-text"
+version = "19.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828"
+checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
 dependencies = [
- "cfg-if 0.1.10",
- "core-foundation-sys 0.7.0",
- "core-graphics 0.19.2",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types 0.3.2",
  "libc",
- "objc",
 ]
 
 [[package]]
@@ -520,6 +506,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossfont"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66b1c1979c4362323f03ab6bf7fb522902bfc418e0c37319ab347f9561d980f"
+dependencies = [
+ "cocoa",
+ "core-foundation",
+ "core-foundation-sys",
+ "core-graphics",
+ "core-text",
+ "dwrote",
+ "foreign-types 0.5.0",
+ "freetype-rs",
+ "libc",
+ "log",
+ "objc",
+ "once_cell",
+ "pkg-config",
+ "servo-fontconfig",
+ "winapi",
 ]
 
 [[package]]
@@ -713,10 +722,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "dwrote"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_derive",
+ "winapi",
+ "wio",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "expat-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
+dependencies = [
+ "cmake",
+ "pkg-config",
+]
 
 [[package]]
 name = "external-memory"
@@ -755,7 +788,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
 ]
 
 [[package]]
@@ -779,7 +812,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -787,6 +841,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -803,6 +863,28 @@ name = "fragile"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
+
+[[package]]
+name = "freetype-rs"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74eadec9d0a5c28c54bb9882e54787275152a4e36ce206b45d7451384e5bf5fb"
+dependencies = [
+ "bitflags",
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+dependencies = [
+ "cmake",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "fs-err"
@@ -852,7 +934,7 @@ dependencies = [
  "gfx-renderdoc",
  "libloading",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "range-alloc",
  "raw-window-handle 0.3.4",
  "smallvec 1.7.0",
@@ -876,7 +958,7 @@ dependencies = [
  "gfx-hal",
  "gfx-renderdoc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "range-alloc",
  "raw-window-handle 0.3.4",
  "smallvec 1.7.0",
@@ -901,7 +983,7 @@ dependencies = [
  "libloading",
  "log",
  "naga",
- "parking_lot",
+ "parking_lot 0.11.2",
  "raw-window-handle 0.3.4",
  "wasm-bindgen",
  "web-sys",
@@ -919,14 +1001,14 @@ dependencies = [
  "cocoa-foundation",
  "copyless",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "fxhash",
  "gfx-hal",
  "log",
  "metal",
  "naga",
  "objc",
- "parking_lot",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle 0.3.4",
@@ -948,7 +1030,7 @@ dependencies = [
  "inplace_it",
  "log",
  "objc",
- "parking_lot",
+ "parking_lot 0.11.2",
  "raw-window-handle 0.3.4",
  "smallvec 1.7.0",
  "winapi",
@@ -1017,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b80b98efaa8a34fce11d60dd2ce2760d5d83c373cbcc73bb87c2a3a84a54108"
 dependencies = [
  "js-sys",
- "slotmap",
+ "slotmap 0.4.3",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1306,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1376,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.3.1"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -1401,7 +1483,7 @@ dependencies = [
  "bitflags",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "log",
  "objc",
 ]
@@ -1420,6 +1502,15 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -1480,14 +1571,15 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d868f654c72e75f8687572699cdabe755f03effbb62542768e995d5b8d699d"
+checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
  "bitflags",
  "jni-sys",
  "ndk-sys",
  "num_enum",
+ "raw-window-handle 0.5.0",
  "thiserror",
 ]
 
@@ -1499,17 +1591,18 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-glue"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71bee8ea72d685477e28bd004cfe1bf99c754d688cd78cad139eae4089484d4"
+checksum = "0434fabdd2c15e0aab768ca31d5b7b333717f03cf02037d5a0a3ff3c278ed67f"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "ndk",
  "ndk-context",
  "ndk-macro",
  "ndk-sys",
+ "once_cell",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -1527,21 +1620,11 @@ dependencies = [
 
 [[package]]
 name = "ndk-sys"
-version = "0.2.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
-
-[[package]]
-name = "nix"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+checksum = "21d83ec9c63ec5bf950200a8e508bdad6659972187b625469f58ef8c08e29046"
 dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
+ "jni-sys",
 ]
 
 [[package]]
@@ -1677,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "openssl-probe"
@@ -1717,7 +1800,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -1732,6 +1825,19 @@ dependencies = [
  "redox_syscall",
  "smallvec 1.7.0",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.7.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1779,6 +1885,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "png"
+version = "0.17.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0e7f4c94ec26ff209cee506314212639d6c91b80afb82984819fafce9df01c"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "flate2",
+ "miniz_oxide 0.5.4",
 ]
 
 [[package]]
@@ -1882,14 +2000,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28f55143d0548dad60bb4fbdc835a3d7ac6acc3324506450c5fdd6e42903a76"
 dependencies = [
  "libc",
- "raw-window-handle 0.4.2",
+ "raw-window-handle 0.4.3",
 ]
 
 [[package]]
 name = "raw-window-handle"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba75eee94a9d5273a68c9e1e105d9cffe1ef700532325788389e5a83e2522b7"
+checksum = "b800beb9b6e7d2df1fe337c9e3d04e3af22a124460fb4c30fcc22c9117cefb41"
+dependencies = [
+ "cty",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
 dependencies = [
  "cty",
 ]
@@ -1988,6 +2115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "safe_arch"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2153,18 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61270629cc6b4d77ec1907db1033d5c2e1a404c412743621981a871dc9c12339"
+dependencies = [
+ "crossfont",
+ "log",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
 
 [[package]]
 name = "secrecy"
@@ -2085,6 +2233,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo-fontconfig"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e3e22fe5fd73d04ebf0daa049d3efe3eae55369ce38ab16d07ddd9ac5c217c"
+dependencies = [
+ "libc",
+ "servo-fontconfig-sys",
+]
+
+[[package]]
+name = "servo-fontconfig-sys"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36b879db9892dfa40f95da1c38a835d41634b825fbd8c4c418093d53c24b388"
+dependencies = [
+ "expat-sys",
+ "freetype-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "shaderc"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf34684c5767b87de9119790e92e9a1d60056be2ceeaf16a8e6ef13082aeab1"
 
 [[package]]
+name = "slotmap"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3"
+checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
  "bitflags",
  "calloop",
@@ -2175,7 +2353,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
- "nix 0.22.3",
+ "nix 0.24.2",
  "pkg-config",
  "wayland-client",
  "wayland-cursor",
@@ -2342,6 +2520,31 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642680569bb895b16e4b9d181c60be1ed136fa0c9c7f11d004daf053ba89bf82"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if 1.0.0",
+ "png",
+ "safe_arch",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c114d32f0c2ee43d585367cb013dfaba967ab9f62b90d9af0d696e955e70fa6c"
+dependencies = [
+ "arrayref",
+ "bytemuck",
 ]
 
 [[package]]
@@ -2750,34 +2953,34 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winit"
-version = "0.26.1"
+version = "0.27.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a"
+checksum = "37f64802920c4c35d12a53dad5e0c55bbc3004d8dc4f2e4dd64ad02c5665d7aa"
 dependencies = [
  "bitflags",
  "cocoa",
- "core-foundation 0.9.2",
- "core-graphics 0.22.3",
- "core-video-sys",
+ "core-foundation",
+ "core-graphics",
  "dispatch",
  "instant",
- "lazy_static",
  "libc",
  "log",
  "mio",
  "ndk",
  "ndk-glue",
- "ndk-sys",
  "objc",
- "parking_lot",
+ "once_cell",
+ "parking_lot 0.12.1",
  "percent-encoding",
- "raw-window-handle 0.4.2",
+ "raw-window-handle 0.4.3",
+ "raw-window-handle 0.5.0",
+ "sctk-adwaita",
  "smithay-client-toolkit",
  "wasm-bindgen",
  "wayland-client",
  "wayland-protocols",
  "web-sys",
- "winapi",
+ "windows-sys",
  "x11-dl",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,6 +1236,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambda_rs_triangles"
+version = "0.1.0"
+dependencies = [
+ "lambda",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = [
     "lambda",
     "crates/lambda-platform",
     "tools/lambda_rs_demo",
-    "tools/minimal"
+    "tools/minimal",
+    "tools/triangles_demo",
 ]
 
 default-members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@
 members = [
     "lambda",
     "crates/lambda-platform",
-    "tools/lambda_rs_demo"
+    "tools/lambda_rs_demo",
+    "tools/minimal"
 ]
 
 default-members = [

--- a/crates/lambda-platform/Cargo.toml
+++ b/crates/lambda-platform/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 gfx-hal = "=0.9.0"
-winit = "=0.26.1"
+winit = "=0.27.4"
 shaderc = "=0.7"
 cfg-if = "=1.0.0"
 

--- a/crates/lambda-platform/src/gfx/api.rs
+++ b/crates/lambda-platform/src/gfx/api.rs
@@ -2,15 +2,15 @@
 //! implementations to use.
 
 cfg_if::cfg_if! {
-  if #[cfg(feature = "with-gl")] {
+  if #[cfg(feature = "gfx-with-gl")] {
     pub use gfx_backend_gl as RenderingAPI;
-  } else if #[cfg(feature = "with-vulkan")] {
+  } else if #[cfg(feature = "gfx-with-vulkan")] {
     pub use gfx_backend_vulkan as RenderingAPI;
-  } else if #[cfg(feature = "with-metal")] {
+  } else if #[cfg(feature = "gfx-with-metal")] {
     pub use gfx_backend_metal as RenderingAPI;
-  } else if #[cfg(feature = "with-dx11")] {
+  } else if #[cfg(feature = "gfx-with-dx11")] {
     pub use gfx_backend_dx11 as RenderingAPI;
-  } else if #[cfg(feature = "with-dx12")] {
+  } else if #[cfg(feature = "gfx-with-dx12")] {
     pub use gfx_backend_dx12 as RenderingAPI;
   } else if #[cfg(feature = "detect-platform")] {
       pub use gfx_platform_backend as RenderingAPI;

--- a/crates/lambda-platform/src/gfx/command.rs
+++ b/crates/lambda-platform/src/gfx/command.rs
@@ -90,6 +90,12 @@ pub enum Command<RenderBackend: gfx_hal::Backend> {
   Draw {
     vertices: Range<u32>,
   },
+  PushConstants {
+    pipeline: Rc<RenderPipeline<RenderBackend>>,
+    stage: super::pipeline::PipelineStage,
+    offset: u32,
+    bytes: &'static [u32],
+  },
   EndRecording,
 }
 
@@ -167,6 +173,17 @@ impl<'command_pool, RenderBackend: gfx_hal::Backend>
           )
         }
         Command::EndRenderPass => self.command_buffer.end_render_pass(),
+        Command::PushConstants {
+          pipeline,
+          stage,
+          offset,
+          bytes,
+        } => self.command_buffer.push_graphics_constants(
+          super::pipeline::internal::pipeline_layout_for(pipeline.as_ref()),
+          stage,
+          offset,
+          bytes,
+        ),
         Command::Draw { vertices } => self.command_buffer.draw(vertices, 0..1),
         Command::EndRecording => self.command_buffer.finish(),
       }

--- a/crates/lambda-platform/src/gfx/command.rs
+++ b/crates/lambda-platform/src/gfx/command.rs
@@ -381,8 +381,9 @@ impl<RenderBackend: gfx_hal::Backend> CommandPool<RenderBackend> {
   /// Moves the command pool into itself and destroys any command pool and
   /// buffer resources allocated on the GPU.
   #[inline]
-  pub fn destroy(self, gpu: &super::gpu::Gpu<RenderBackend>) {
+  pub fn destroy(mut self, gpu: &super::gpu::Gpu<RenderBackend>) {
     unsafe {
+      self.command_pool.reset(true);
       super::gpu::internal::logical_device_for(gpu)
         .destroy_command_pool(self.command_pool);
     }

--- a/crates/lambda-platform/src/gfx/command.rs
+++ b/crates/lambda-platform/src/gfx/command.rs
@@ -94,7 +94,7 @@ pub enum Command<RenderBackend: gfx_hal::Backend> {
     pipeline: Rc<RenderPipeline<RenderBackend>>,
     stage: super::pipeline::PipelineStage,
     offset: u32,
-    bytes: &'static [u32],
+    bytes: Vec<u32>,
   },
   EndRecording,
 }
@@ -182,7 +182,7 @@ impl<'command_pool, RenderBackend: gfx_hal::Backend>
           super::pipeline::internal::pipeline_layout_for(pipeline.as_ref()),
           stage,
           offset,
-          bytes,
+          bytes.as_slice(),
         ),
         Command::Draw { vertices } => self.command_buffer.draw(vertices, 0..1),
         Command::EndRecording => self.command_buffer.finish(),

--- a/crates/lambda-platform/src/gfx/fence.rs
+++ b/crates/lambda-platform/src/gfx/fence.rs
@@ -133,4 +133,10 @@ pub mod internal {
   ) -> &mut RenderBackend::Semaphore {
     return &mut semaphore.semaphore;
   }
+
+  pub fn semaphore_for<RenderBackend: gfx_hal::Backend>(
+    semaphore: &super::RenderSemaphore<RenderBackend>,
+  ) -> &RenderBackend::Semaphore {
+    return &semaphore.semaphore;
+  }
 }

--- a/crates/lambda-platform/src/gfx/framebuffer.rs
+++ b/crates/lambda-platform/src/gfx/framebuffer.rs
@@ -10,6 +10,7 @@ use super::{
 };
 
 /// Framebuffer for the given render backend.
+#[derive(Debug)]
 pub struct Framebuffer<RenderBackend: gfx_hal::Backend> {
   frame_buffer: RenderBackend::Framebuffer,
 }

--- a/crates/lambda-platform/src/gfx/gpu.rs
+++ b/crates/lambda-platform/src/gfx/gpu.rs
@@ -158,7 +158,6 @@ impl<RenderBackend: gfx_hal::Backend> Gpu<RenderBackend> {
     let (render_surface, render_image) =
       super::surface::internal::borrow_surface_and_take_image(surface);
 
-    println!("Rendering to surface.");
     let result = unsafe {
       self.queue_group.queues[0].present(
         render_surface,
@@ -173,8 +172,6 @@ impl<RenderBackend: gfx_hal::Backend> Gpu<RenderBackend> {
         "Rendering failed. Swapchain for the surface needs to be reconfigured.",
       );
     }
-
-    println!("Rendered to surface.");
 
     return Ok(());
   }

--- a/crates/lambda-platform/src/gfx/pipeline.rs
+++ b/crates/lambda-platform/src/gfx/pipeline.rs
@@ -89,13 +89,13 @@ impl<RenderBackend: internal::Backend> RenderPipelineBuilder<RenderBackend> {
   ) -> RenderPipeline<RenderBackend> {
     // TODO(vmarcella): The pipeline layout should be configurable through the
     // RenderPipelineBuilder.
+    let push_constants = self.push_constants.into_iter();
+
     let pipeline_layout = unsafe {
       use internal::Device;
+
       super::internal::logical_device_for(gpu)
-        .create_pipeline_layout(
-          vec![].into_iter(),
-          self.push_constants.into_iter(),
-        )
+        .create_pipeline_layout(vec![].into_iter(), push_constants)
         .expect(
           "The GPU does not have enough memory to allocate a pipeline layout",
         )

--- a/crates/lambda-platform/src/gfx/render_pass.rs
+++ b/crates/lambda-platform/src/gfx/render_pass.rs
@@ -125,7 +125,7 @@ impl SubpassBuilder {
     };
   }
 
-  pub fn use_color_attachment(
+  pub fn with_color_attachment(
     mut self,
     attachment_index: usize,
     layout: ImageLayoutHint,

--- a/crates/lambda-platform/src/gfx/render_pass.rs
+++ b/crates/lambda-platform/src/gfx/render_pass.rs
@@ -224,16 +224,13 @@ impl<'builder> RenderPassBuilder<'builder> {
     };
 
     let render_pass = unsafe {
-      super::internal::logical_device_for(gpu)
-        .create_render_pass(
-          attachments.into_iter(),
-          subpasses.into_iter(),
-          vec![].into_iter(),
-        )
-        .expect(
-          "The GPU does not have enough memory to allocate a render pass.",
-        )
-    };
+      super::internal::logical_device_for(gpu).create_render_pass(
+        attachments.into_iter(),
+        subpasses.into_iter(),
+        vec![].into_iter(),
+      )
+    }
+    .expect("The GPU does not have enough memory to allocate a render pass.");
 
     return RenderPass { render_pass };
   }

--- a/crates/lambda-platform/src/gfx/shader.rs
+++ b/crates/lambda-platform/src/gfx/shader.rs
@@ -29,7 +29,7 @@ impl ShaderModuleBuilder {
   pub fn new() -> Self {
     return Self {
       entry_name: "main".to_string(),
-      specializations: ShaderSpecializations::default(),
+      specializations: ShaderSpecializations::EMPTY,
     };
   }
 

--- a/crates/lambda-platform/src/gfx/shader.rs
+++ b/crates/lambda-platform/src/gfx/shader.rs
@@ -1,5 +1,5 @@
 //! Low level shader implementations used by the lambda-platform crate to load
-//! RISC-V compiled shaders into the GPU.
+//! SPIR-V compiled shaders into the GPU.
 
 use gfx_hal::{
   device::Device,

--- a/crates/lambda-platform/src/winit/mod.rs
+++ b/crates/lambda-platform/src/winit/mod.rs
@@ -7,6 +7,7 @@ use winit::{
   event_loop::{
     ControlFlow,
     EventLoop,
+    EventLoopBuilder,
     EventLoopProxy,
     EventLoopWindowTarget,
   },
@@ -45,7 +46,7 @@ impl LoopBuilder {
   }
 
   pub fn build<Events: 'static + std::fmt::Debug>(self) -> Loop<Events> {
-    let event_loop = EventLoop::<Events>::with_user_event();
+    let event_loop = EventLoopBuilder::<Events>::with_user_event().build();
     return Loop { event_loop };
   }
 }

--- a/lambda/src/core/component.rs
+++ b/lambda/src/core/component.rs
@@ -19,7 +19,6 @@ pub trait RenderableComponent<E>: Component<E> {
   fn on_render(
     &mut self,
     render_context: &mut super::render::RenderContext,
-    last_render: &Duration,
   ) -> Vec<super::render::command::RenderCommand>;
   fn on_renderer_detached(
     &mut self,

--- a/lambda/src/core/component.rs
+++ b/lambda/src/core/component.rs
@@ -1,27 +1,27 @@
 use std::time::Duration;
 
+use super::{
+  events::Events,
+  render::{
+    command::RenderCommand,
+    RenderContext,
+  },
+};
+
 /// The Component Interface for allowing Component based data structures
 /// like the ComponentStack to store components with various purposes
 /// and implementations to work together.
-pub trait Component<E> {
-  fn on_attach(&mut self);
-  fn on_detach(&mut self);
-  fn on_event(&mut self, event: &E);
-  fn on_update(&mut self, last_frame: &Duration);
-}
+pub trait Component {
+  fn on_attach(&mut self, render_context: &mut RenderContext);
+  fn on_detach(&mut self, render_context: &mut RenderContext);
+  fn on_event(&mut self, event: Events);
 
-/// The interface for a Component that can be rendered.
-pub trait RenderableComponent<E>: Component<E> {
-  fn on_renderer_attached(
-    &mut self,
-    render_context: &mut super::render::RenderContext,
-  );
+  /// When the application state should perform logic updates.
+  fn on_update(&mut self, last_frame: &Duration);
+
+  /// When the application state should perform rendering.
   fn on_render(
     &mut self,
-    render_context: &mut super::render::RenderContext,
-  ) -> Vec<super::render::command::RenderCommand>;
-  fn on_renderer_detached(
-    &mut self,
-    render_context: &mut super::render::RenderContext,
-  );
+    render_context: &mut RenderContext,
+  ) -> Vec<RenderCommand>;
 }

--- a/lambda/src/core/render/command.rs
+++ b/lambda/src/core/render/command.rs
@@ -33,6 +33,12 @@ pub enum RenderCommand {
   },
   /// Ends the render pass.
   EndRenderPass,
+  PushConstants {
+    pipeline: Rc<super::pipeline::RenderPipeline>,
+    stage: super::pipeline::PipelineStage,
+    offset: u32,
+    bytes: &'static [u32],
+  },
   /// Draws a graphical primitive.
   Draw { vertices: Range<u32> },
 }
@@ -87,6 +93,17 @@ impl RenderCommand {
           pipeline: pipeline.into_platform_render_pipeline(),
         }
       }
+      RenderCommand::PushConstants {
+        pipeline,
+        stage,
+        offset,
+        bytes,
+      } => PlatformRenderCommand::PushConstants {
+        pipeline: pipeline.into_platform_render_pipeline(),
+        stage,
+        offset,
+        bytes,
+      },
       RenderCommand::Draw { vertices } => {
         PlatformRenderCommand::Draw { vertices }
       }

--- a/lambda/src/core/render/command.rs
+++ b/lambda/src/core/render/command.rs
@@ -37,7 +37,7 @@ pub enum RenderCommand {
     pipeline: Rc<super::pipeline::RenderPipeline>,
     stage: super::pipeline::PipelineStage,
     offset: u32,
-    bytes: &'static [u32],
+    bytes: Vec<u32>,
   },
   /// Draws a graphical primitive.
   Draw { vertices: Range<u32> },

--- a/lambda/src/core/render/command.rs
+++ b/lambda/src/core/render/command.rs
@@ -24,23 +24,25 @@ pub enum RenderCommand {
     viewports: Vec<super::viewport::Viewport>,
   },
   SetPipeline {
-    pipeline: Rc<super::pipeline::RenderPipeline>,
+    pipeline: super::ResourceId,
   },
   /// Begins the render pass.
   BeginRenderPass {
-    render_pass: Rc<super::render_pass::RenderPass>,
+    render_pass: super::ResourceId,
     viewport: super::viewport::Viewport,
   },
   /// Ends the render pass.
   EndRenderPass,
   PushConstants {
-    pipeline: Rc<super::pipeline::RenderPipeline>,
+    pipeline: super::ResourceId,
     stage: super::pipeline::PipelineStage,
     offset: u32,
     bytes: Vec<u32>,
   },
   /// Draws a graphical primitive.
-  Draw { vertices: Range<u32> },
+  Draw {
+    vertices: Range<u32>,
+  },
 }
 
 impl RenderCommand {
@@ -76,12 +78,17 @@ impl RenderCommand {
         viewport,
       } => {
         let surface = surface_from_context(render_context);
-        let render_pass = render_pass.into_gfx_render_pass();
-        let frame_buffer =
-          render_context.allocate_and_get_frame_buffer(render_pass.as_ref());
+        let frame_buffer = render_context.allocate_and_get_frame_buffer(
+          render_context
+            .get_render_pass(render_pass)
+            .into_gfx_render_pass()
+            .as_ref(),
+        );
 
         PlatformRenderCommand::BeginRenderPass {
-          render_pass: render_pass.clone(),
+          render_pass: render_context
+            .get_render_pass(render_pass)
+            .into_gfx_render_pass(),
           surface: surface.clone(),
           frame_buffer: frame_buffer.clone(),
           viewport: viewport.into_gfx_viewport(),
@@ -90,7 +97,11 @@ impl RenderCommand {
       RenderCommand::EndRenderPass => PlatformRenderCommand::EndRenderPass,
       RenderCommand::SetPipeline { pipeline } => {
         PlatformRenderCommand::AttachGraphicsPipeline {
-          pipeline: pipeline.into_platform_render_pipeline(),
+          pipeline: render_context
+            .render_pipelines
+            .get(pipeline)
+            .unwrap()
+            .into_platform_render_pipeline(),
         }
       }
       RenderCommand::PushConstants {
@@ -99,7 +110,11 @@ impl RenderCommand {
         offset,
         bytes,
       } => PlatformRenderCommand::PushConstants {
-        pipeline: pipeline.into_platform_render_pipeline(),
+        pipeline: render_context
+          .render_pipelines
+          .get(pipeline)
+          .unwrap()
+          .into_platform_render_pipeline(),
         stage,
         offset,
         bytes,

--- a/lambda/src/core/render/mod.rs
+++ b/lambda/src/core/render/mod.rs
@@ -232,15 +232,17 @@ impl RenderContext {
     command_buffer.issue_commands(platform_command_list);
     command_buffer.issue_command(PlatformRenderCommand::EndRecording);
 
+    println!("[INFO] {} will now submit commands to the GPU.", self.name);
     self.gpu.submit_command_buffer(
       &mut command_buffer,
-      vec![],
+      vec![self.render_semaphore.as_ref().unwrap()],
       self
         .submission_fence
         .as_mut()
         .expect("Failed to get mutable reference to submission fence."),
     );
 
+    println!("[INFO] {} will now render to the surface.", self.name);
     self
       .gpu
       .render_to_surface(
@@ -250,6 +252,10 @@ impl RenderContext {
       )
       .expect("Failed to render to the surface");
 
+    println!(
+      "[INFO] {} will now wait for the GPU to finish rendering.",
+      self.name
+    );
     match self.frame_buffer {
       Some(_) => {
         Rc::try_unwrap(self.frame_buffer.take().unwrap())

--- a/lambda/src/core/render/pipeline.rs
+++ b/lambda/src/core/render/pipeline.rs
@@ -40,11 +40,27 @@ impl RenderPipeline {
   }
 }
 
-pub struct RenderPipelineBuilder {}
+pub use lambda_platform::gfx::pipeline::PipelineStage;
+use lambda_platform::gfx::pipeline::PushConstantUpload;
+
+pub struct RenderPipelineBuilder {
+  push_constants: Vec<PushConstantUpload>,
+}
 
 impl RenderPipelineBuilder {
   pub fn new() -> Self {
-    return Self {};
+    return Self {
+      push_constants: Vec::new(),
+    };
+  }
+
+  pub fn with_push_constant(
+    mut self,
+    stage: PipelineStage,
+    bytes: u32,
+  ) -> Self {
+    self.push_constants.push((stage, 0..bytes));
+    return self;
   }
 
   /// Builds a render pipeline based on your builder configuration.
@@ -68,12 +84,14 @@ impl RenderPipelineBuilder {
     );
 
     let render_pipeline =
-      lambda_platform::gfx::pipeline::RenderPipelineBuilder::new().build(
-        gpu_from_context(render_context),
-        &platform_render_pass_from_render_pass(render_pass),
-        &vertex_shader_module,
-        &fragment_shader_module,
-      );
+      lambda_platform::gfx::pipeline::RenderPipelineBuilder::new()
+        .with_push_constants(self.push_constants)
+        .build(
+          gpu_from_context(render_context),
+          &platform_render_pass_from_render_pass(render_pass),
+          &vertex_shader_module,
+          &fragment_shader_module,
+        );
 
     vertex_shader_module.destroy(mut_gpu_from_context(render_context));
     fragment_shader_module.destroy(mut_gpu_from_context(render_context));

--- a/lambda/src/core/render/shader.rs
+++ b/lambda/src/core/render/shader.rs
@@ -20,12 +20,12 @@ impl ShaderBuilder {
 
   /// Compiles the virtual shader into a real shader with SPIR-V binary
   /// representation.
-  pub fn build(&mut self, meta_shader: VirtualShader) -> Shader {
-    let binary = self.compiler.compile_into_binary(&meta_shader);
+  pub fn build(&mut self, virtual_shader: VirtualShader) -> Shader {
+    let binary = self.compiler.compile_into_binary(&virtual_shader);
 
     return Shader {
       binary,
-      virtual_shader: meta_shader,
+      virtual_shader,
     };
   }
 }

--- a/lambda/src/math/mod.rs
+++ b/lambda/src/math/mod.rs
@@ -1,7 +1,1 @@
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct Triangle {
-  color: [f32; 4],
-  pos: [f32; 2],
-  scale: [f32; 2],
-}
+type Vec2 = (f32, f32);

--- a/lambda/src/runtimes/mod.rs
+++ b/lambda/src/runtimes/mod.rs
@@ -254,6 +254,7 @@ impl Runtime for GenericRuntime {
           } => {}
           WinitWindowEvent::Touch(_) => {}
           WinitWindowEvent::ThemeChanged(_) => {}
+          _ => {}
         },
         WinitEvent::MainEventsCleared => {
           let last_frame = current_frame.clone();

--- a/lambda/src/runtimes/mod.rs
+++ b/lambda/src/runtimes/mod.rs
@@ -260,17 +260,19 @@ impl Runtime for GenericRuntime {
           current_frame = Instant::now();
           let duration = &current_frame.duration_since(last_frame);
 
-          let render_api = active_render_context.as_mut().unwrap();
           // Update and render commands.
           for component in &mut component_stack {
             component.on_update(duration);
-            let commands = component.on_render(render_api, duration);
-            render_api.render(commands);
           }
 
           window.redraw();
         }
-        WinitEvent::RedrawRequested(_) => {}
+        WinitEvent::RedrawRequested(_) => {
+          for component in &mut component_stack {
+            let commands = component.on_render(active_render_context.as_mut().unwrap());
+            active_render_context.as_mut().unwrap().render(commands);
+          }
+        }
         WinitEvent::NewEvents(_) => {}
         WinitEvent::DeviceEvent { device_id, event } => {}
         WinitEvent::UserEvent(lambda_event) => match lambda_event {

--- a/lambda/src/runtimes/mod.rs
+++ b/lambda/src/runtimes/mod.rs
@@ -156,6 +156,8 @@ impl Runtime for GenericRuntime {
               event: RuntimeEvent::Shutdown,
               issued_at: Instant::now(),
             });
+
+            *control_flow = ControlFlow::Exit;
           }
           WinitWindowEvent::Resized(dims) => {
             active_render_context
@@ -292,7 +294,6 @@ impl Runtime for GenericRuntime {
                 component
                   .on_renderer_detached(active_render_context.as_mut().unwrap());
               }
-              *control_flow = ControlFlow::Exit;
             }
           },
           _ => {

--- a/tools/lambda_rs_demo/src/main.rs
+++ b/tools/lambda_rs_demo/src/main.rs
@@ -136,7 +136,6 @@ impl RenderableComponent<Events> for DemoComponent {
   fn on_render(
     self: &mut DemoComponent,
     _render_context: &mut lambda::core::render::RenderContext,
-    _last_render: &std::time::Duration,
   ) -> Vec<RenderCommand> {
     let viewport =
       viewport::ViewportBuilder::new().build(self.width, self.height);

--- a/tools/lambda_rs_demo/src/main.rs
+++ b/tools/lambda_rs_demo/src/main.rs
@@ -156,6 +156,7 @@ impl RenderableComponent<Events> for DemoComponent {
         viewport: viewport.clone(),
       },
       RenderCommand::Draw { vertices: 0..3 },
+      RenderCommand::EndRenderPass,
     ];
   }
 

--- a/tools/minimal/Cargo.toml
+++ b/tools/minimal/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "lambda_rs_demo"
+name = "lambda_rs_minimal"
 version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "demo"
+name = "minimal_demo"
 path = "src/main.rs"
 
 [dependencies]

--- a/tools/minimal/src/main.rs
+++ b/tools/minimal/src/main.rs
@@ -1,3 +1,8 @@
+//! Minimal application which configures a window & render context before
+//! starting the runtime. You can use this as a starting point for your own
+//! applications or to verify that your system is configured to run lambda
+//! applications correctly.
+
 use lambda::{
   core::runtime::start_runtime,
   runtimes::GenericRuntimeBuilder,

--- a/tools/minimal/src/main.rs
+++ b/tools/minimal/src/main.rs
@@ -1,0 +1,19 @@
+use lambda::{
+  core::runtime::start_runtime,
+  runtimes::GenericRuntimeBuilder,
+};
+
+fn main() {
+  let runtime = GenericRuntimeBuilder::new("Minimal Demo application")
+    .with_renderer_configured_as(move |render_context_builder| {
+      return render_context_builder.with_render_timeout(1_000_000_000);
+    })
+    .with_window_configured_as(move |window_builder| {
+      return window_builder
+        .with_dimensions(800, 600)
+        .with_name("Minimal window");
+    })
+    .build();
+
+  start_runtime(runtime);
+}

--- a/tools/triangles_demo/Cargo.toml
+++ b/tools/triangles_demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lambda_rs_triangles"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "triangles"
+path = "src/main.rs"
+
+[dependencies]
+lambda = { path = "../../lambda" }

--- a/tools/triangles_demo/assets/triangles.frag
+++ b/tools/triangles_demo/assets/triangles.frag
@@ -1,0 +1,10 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+layout(location = 0) in vec4 vertex_color;
+
+layout(location = 0) out vec4 fragment_color;
+
+void main() {
+  fragment_color = vertex_color;
+}

--- a/tools/triangles_demo/assets/triangles.vert
+++ b/tools/triangles_demo/assets/triangles.vert
@@ -1,14 +1,13 @@
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 
+layout(push_constant) uniform PushConstant {
+  vec4 color;
+  vec2 pos;
+  vec2 scale;
+} pcs;
 
 layout(location = 0) out vec4 vertex_color;
-
-layout( push_constant ) uniform Block {
-    vec4 color;
-    vec2 position;
-    vec2 scale;
-} PushConstants;
 
 vec2 positions[3] = vec2[](
   vec2(0.0, -0.5),
@@ -17,7 +16,7 @@ vec2 positions[3] = vec2[](
 );
 
 void main() {
-  vec2 position = positions[gl_VertexIndex] * PushConstants.scale;
-  vertex_color = PushConstants.color;
-  gl_Position = vec4((position + PushConstants.position), 0.0, 1.0);
+  vec2 position = positions[gl_VertexIndex] * pcs.scale;
+  vertex_color = pcs.color;
+  gl_Position = vec4((position + pcs.pos), 0.0, 1.0);
 }

--- a/tools/triangles_demo/assets/triangles.vert
+++ b/tools/triangles_demo/assets/triangles.vert
@@ -1,0 +1,23 @@
+#version 450
+#extension GL_ARB_separate_shader_objects : enable
+
+
+layout(location = 0) out vec4 vertex_color;
+
+layout( push_constant ) uniform Block {
+    vec4 color;
+    vec2 position;
+    vec2 scale;
+} PushConstants;
+
+vec2 positions[3] = vec2[](
+  vec2(0.0, -0.5),
+  vec2(-0.5, 0.5),
+  vec2(0.5, 0.5)
+);
+
+void main() {
+  vec2 position = positions[gl_VertexIndex] * PushConstants.scale;
+  vertex_color = PushConstants.color;
+  gl_Position = vec4((position + PushConstants.position), 0.0, 1.0);
+}

--- a/tools/triangles_demo/src/main.rs
+++ b/tools/triangles_demo/src/main.rs
@@ -1,0 +1,261 @@
+use std::rc::Rc;
+
+use lambda::{
+  core::{
+    component::{
+      Component,
+      RenderableComponent,
+    },
+    events::{
+      Events,
+      WindowEvent,
+    },
+    render::{
+      command::RenderCommand,
+      pipeline::{
+        self,
+        PipelineStage,
+        RenderPipeline,
+      },
+      render_pass::{
+        self,
+        RenderPass,
+      },
+      shader::{
+        Shader,
+        ShaderBuilder,
+        ShaderKind,
+        VirtualShader,
+      },
+      viewport,
+    },
+    runtime::start_runtime,
+  },
+  runtimes::GenericRuntimeBuilder,
+};
+
+pub struct TrianglesComponent {
+  triangle_vertex: Shader,
+  vertex_shader: Shader,
+  render_pass: Option<Rc<RenderPass>>,
+  render_pipeline: Option<Rc<RenderPipeline>>,
+  width: u32,
+  height: u32,
+}
+
+impl Component<Events> for TrianglesComponent {
+  fn on_attach(&mut self) {
+    println!("Attached the DemoComponent.");
+  }
+
+  fn on_detach(&mut self) {}
+
+  fn on_event(&mut self, event: &lambda::core::events::Events) {
+    match event {
+      Events::Runtime { event, issued_at } => match event {
+        lambda::core::events::RuntimeEvent::Shutdown => {
+          println!("Shutting down the runtime");
+        }
+        _ => {}
+      },
+      Events::Window { event, issued_at } => match event {
+        WindowEvent::Resize { width, height } => {
+          println!("Window resized to {}x{}", width, height);
+          self.width = *width;
+          self.height = *height;
+        }
+        WindowEvent::Close => {
+          println!("Window closed");
+        }
+      },
+      _ => {}
+    }
+  }
+
+  fn on_update(&mut self, last_frame: &std::time::Duration) {
+    match last_frame.as_millis() > 20 {
+      true => {
+        println!("[WARN] Last frame took {}ms", last_frame.as_millis());
+      }
+      false => {}
+    }
+  }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PushConstant {
+  color: [f32; 4],
+  position: [f32; 2],
+  scale: [f32; 2],
+}
+
+pub fn push_constants_to_bytes(push_constants: &PushConstant) -> &[u32] {
+  let bytes = unsafe {
+    let size_in_bytes = std::mem::size_of::<PushConstant>();
+    let size_in_u32 = size_in_bytes / std::mem::size_of::<u32>();
+    let ptr = push_constants as *const PushConstant as *const u32;
+    std::slice::from_raw_parts(ptr, size_in_u32)
+  };
+
+  return bytes;
+}
+
+/// Implement rendering for the component.
+impl RenderableComponent<Events> for TrianglesComponent {
+  fn on_renderer_attached(
+    &mut self,
+    render_context: &mut lambda::core::render::RenderContext,
+  ) {
+    println!("Attached the demo component to the renderer");
+    let render_pass =
+      Rc::new(render_pass::RenderPassBuilder::new().build(&render_context));
+
+    self.render_pass = Some(render_pass.clone());
+
+    let push_constants_size = std::mem::size_of::<PushConstant>() as u32;
+    println!("Push constant size: {}", push_constants_size);
+    let pipeline = Rc::new(
+      pipeline::RenderPipelineBuilder::new()
+        .with_push_constant(PipelineStage::VERTEX, push_constants_size)
+        .build(
+          render_context,
+          &self.render_pass.as_ref().unwrap(),
+          &self.vertex_shader,
+          &self.triangle_vertex,
+        ),
+    );
+
+    self.render_pipeline = Some(pipeline.clone());
+  }
+
+  fn on_render(
+    &mut self,
+    _render_context: &mut lambda::core::render::RenderContext,
+  ) -> Vec<RenderCommand> {
+    let viewport =
+      viewport::ViewportBuilder::new().build(self.width, self.height);
+
+    let triangle_data = &[
+      PushConstant {
+        color: [1.0, 0.0, 0.0, 1.0],
+        position: [0.0, 0.0],
+        scale: [0.3, 0.3],
+      },
+      PushConstant {
+        color: [0.0, 1.0, 0.0, 1.0],
+        position: [0.5, 0.0],
+        scale: [0.4, 0.4],
+      },
+      PushConstant {
+        color: [0.0, 0.0, 1.0, 1.0],
+        position: [0.25, 0.5],
+        scale: [0.5, 0.5],
+      },
+      PushConstant {
+        color: [1.0, 1.0, 1.0, 1.0],
+        position: [0.0, 0.0],
+        scale: [0.5, 0.5],
+      },
+    ];
+
+    let render_pipeline = self
+      .render_pipeline
+      .as_ref()
+      .expect("No render pipeline actively set for rendering.");
+
+    let mut commands = vec![
+      RenderCommand::SetViewports {
+        start_at: 0,
+        viewports: vec![viewport.clone()],
+      },
+      RenderCommand::SetScissors {
+        start_at: 0,
+        viewports: vec![viewport.clone()],
+      },
+      RenderCommand::SetPipeline {
+        pipeline: render_pipeline.clone(),
+      },
+      RenderCommand::BeginRenderPass {
+        render_pass: self
+          .render_pass
+          .as_ref()
+          .expect("Cannot begin the render pass when it doesn't exist.")
+          .clone(),
+        viewport: viewport.clone(),
+      },
+    ];
+
+    for triangle in triangle_data {
+      commands.push(RenderCommand::PushConstants {
+        pipeline: render_pipeline.clone(),
+        stage: PipelineStage::VERTEX,
+        offset: 0,
+        bytes: push_constants_to_bytes(triangle),
+      });
+      commands.push(RenderCommand::Draw { vertices: 0..3 });
+    }
+
+    return commands;
+  }
+
+  fn on_renderer_detached(
+    &mut self,
+    _render_context: &mut lambda::core::render::RenderContext,
+  ) {
+    println!("Detached the demo component from the renderer");
+  }
+}
+
+impl Default for TrianglesComponent {
+  /// Load in shaders upon creation.
+
+  fn default() -> Self {
+    // Specify virtual shaders to use for rendering
+    let triangle_vertex = VirtualShader::Source {
+      source: include_str!("../assets/triangles.vert").to_string(),
+      kind: ShaderKind::Vertex,
+      name: String::from("triangles"),
+      entry_point: String::from("main"),
+    };
+
+    let triangle_fragment = VirtualShader::Source {
+      source: include_str!("../assets/triangles.frag").to_string(),
+      kind: ShaderKind::Fragment,
+      name: String::from("triangles"),
+      entry_point: String::from("main"),
+    };
+
+    // Create a shader builder to compile the shaders.
+    let mut builder = ShaderBuilder::new();
+    let vs = builder.build(triangle_vertex);
+    let fs = builder.build(triangle_fragment);
+
+    return TrianglesComponent {
+      vertex_shader: vs,
+      triangle_vertex: fs,
+      render_pass: None,
+      render_pipeline: None,
+      width: 800,
+      height: 600,
+    };
+  }
+}
+
+fn main() {
+  let runtime = GenericRuntimeBuilder::new("Multiple Triangles Demo")
+    .with_renderer_configured_as(move |render_context_builder| {
+      return render_context_builder.with_render_timeout(1_000_000_000);
+    })
+    .with_window_configured_as(move |window_builder| {
+      return window_builder
+        .with_dimensions(800, 600)
+        .with_name("Triangles");
+    })
+    .with_component(move |runtime, triangles: TrianglesComponent| {
+      return (runtime, triangles);
+    })
+    .build();
+
+  start_runtime(runtime);
+}

--- a/tools/triangles_demo/src/main.rs
+++ b/tools/triangles_demo/src/main.rs
@@ -86,7 +86,7 @@ impl Component<Events> for TrianglesComponent {
 #[derive(Debug, Copy, Clone)]
 pub struct PushConstant {
   color: [f32; 4],
-  position: [f32; 2],
+  pos: [f32; 2],
   scale: [f32; 2],
 }
 
@@ -98,6 +98,7 @@ pub fn push_constants_to_bytes(push_constants: &PushConstant) -> &[u32] {
     std::slice::from_raw_parts(ptr, size_in_u32)
   };
 
+  println!("Push constants: {:?}", bytes);
   return bytes;
 }
 
@@ -125,6 +126,7 @@ impl RenderableComponent<Events> for TrianglesComponent {
           &self.triangle_vertex,
         ),
     );
+    println!("Created pipeline: {:?}", pipeline);
 
     self.render_pipeline = Some(pipeline.clone());
   }
@@ -136,25 +138,26 @@ impl RenderableComponent<Events> for TrianglesComponent {
     let viewport =
       viewport::ViewportBuilder::new().build(self.width, self.height);
 
+    println!("Rendering the demo component");
     let triangle_data = &[
       PushConstant {
         color: [1.0, 0.0, 0.0, 1.0],
-        position: [0.0, 0.0],
+        pos: [0.0, 0.0],
         scale: [0.3, 0.3],
       },
       PushConstant {
         color: [0.0, 1.0, 0.0, 1.0],
-        position: [0.5, 0.0],
+        pos: [0.5, 0.0],
         scale: [0.4, 0.4],
       },
       PushConstant {
         color: [0.0, 0.0, 1.0, 1.0],
-        position: [0.25, 0.5],
+        pos: [0.25, 0.5],
         scale: [0.5, 0.5],
       },
       PushConstant {
         color: [1.0, 1.0, 1.0, 1.0],
-        position: [0.0, 0.0],
+        pos: [0.0, 0.0],
         scale: [0.5, 0.5],
       },
     ];
@@ -191,7 +194,7 @@ impl RenderableComponent<Events> for TrianglesComponent {
         pipeline: render_pipeline.clone(),
         stage: PipelineStage::VERTEX,
         offset: 0,
-        bytes: push_constants_to_bytes(triangle),
+        bytes: Vec::from(push_constants_to_bytes(triangle)),
       });
       commands.push(RenderCommand::Draw { vertices: 0..3 });
     }

--- a/tools/triangles_demo/src/main.rs
+++ b/tools/triangles_demo/src/main.rs
@@ -186,12 +186,6 @@ impl Component for TrianglesComponent {
   }
 
   fn on_update(&mut self, last_frame: &std::time::Duration) {
-    match self.animation_scalar {
-      0.0..=0.5 => self.animation_scalar += last_frame.as_secs_f32(),
-      0.5..=1.0 => self.animation_scalar -= last_frame.as_secs_f32(),
-      _ => self.animation_scalar = 0.0,
-    }
-
     match last_frame.as_millis() > 20 {
       true => {
         println!("[WARN] Last frame took {}ms", last_frame.as_millis());

--- a/tools/triangles_demo/src/main.rs
+++ b/tools/triangles_demo/src/main.rs
@@ -73,7 +73,12 @@ impl Component for TrianglesComponent {
 
     let triangle_data = &[
       PushConstant {
-        color: [1.0, 1.0, 0.0, 1.0],
+        color: [
+          1.0,
+          1.0 * self.animation_scalar,
+          0.5 * self.animation_scalar,
+          1.0,
+        ],
         pos: [x, y],
         scale: [0.3, 0.3],
       },
@@ -161,10 +166,10 @@ impl Component for TrianglesComponent {
           virtual_key,
         } => match virtual_key {
           Some(VirtualKey::W) => {
-            self.position.1 += 0.01;
+            self.position.1 -= 0.01;
           }
           Some(VirtualKey::S) => {
-            self.position.1 -= 0.01;
+            self.position.1 += 0.01;
           }
           Some(VirtualKey::A) => {
             self.position.0 -= 0.01;

--- a/tools/triangles_demo/src/main.rs
+++ b/tools/triangles_demo/src/main.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use lambda::{
   core::{
     component::{
@@ -15,12 +13,8 @@ use lambda::{
       pipeline::{
         self,
         PipelineStage,
-        RenderPipeline,
       },
-      render_pass::{
-        self,
-        RenderPass,
-      },
+      render_pass,
       shader::{
         Shader,
         ShaderBuilder,
@@ -98,7 +92,6 @@ pub fn push_constants_to_bytes(push_constants: &PushConstant) -> &[u32] {
     std::slice::from_raw_parts(ptr, size_in_u32)
   };
 
-  println!("Push constants: {:?}", bytes);
   return bytes;
 }
 


### PR DESCRIPTION
* Changed the `Component` trait to be integrated with the render context and to not be generic. 
* `RenderCommand` now uses resource IDs to access `RenderPass` & `RenderPipeline` attached to the context.  
* Adds a new demo `lambda_minimal_demo` which showcases the smallest amount of code you can create a running application  & window with.
* Adds a new demo `lambda_triangles_demo` which showcases rendering multiple triangles with different properties through the use of GLSL push constants & applying animations (albeit somewhat laggy when running with Vulkan).
* Fixes an issue with rendering semaphores not being submitted with command buffers to the render command queue.
* Fixes an issue with `lambda-platform` not setting the correct gpu backend
* Updates `winit` to `0.27.4`