### PR TITLE
Fix logger singleton

### DIFF
--- a/crates/lambda-rs-logging/Cargo.toml
+++ b/crates/lambda-rs-logging/Cargo.toml
@@ -8,3 +8,6 @@ license = "MIT"
 [lib]
 name = "logging"
 path = "src/lib.rs"
+
+[dependencies]
+once_cell = "1"


### PR DESCRIPTION
## Summary
- use `once_cell` to lazily create the global logger
- add `once_cell` as a dependency

## Testing
- `cargo build -p lambda-rs-logging --offline` *(fails: could not download crates index)*
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_685874d4eaa88332b854d254e7d283c6