### PR TITLE
feat: logging improvements

### DIFF
--- a/crates/lambda-rs-logging/README.md
+++ b/crates/lambda-rs-logging/README.md
@@ -2,48 +2,87 @@
 ![lambda-rs](https://img.shields.io/crates/d/lambda-rs-logging)
 ![lambda-rs](https://img.shields.io/crates/v/lambda-rs-logging)
 
-A simple logger implementation for lamba-rs crates. Inspired by
-python's [logging](https://docs.python.org/3/library/logging.html) module.
+Simple, lightweight logging for lambda-rs crates. Inspired by Python’s
+[logging](https://docs.python.org/3/library/logging.html) module.
 
 
-# Installation
-First, add the following to your `Cargo.toml`:
+## Installation
+Add to your `Cargo.toml`:
 ```toml
 [dependencies]
+# Option A: use the crate name in code as `lambda_rs_logging`
 lambda-rs-logging = "2023.1.30"
+
+# Option B: rename dependency so you can write `use logging;`
+# logging = { package = "lambda-rs-logging", version = "2023.1.30" }
 ```
 
-or run this command from your project directory:
+Or from your project directory:
 ```bash
 cargo add lambda-rs-logging
 ```
 
-# Getting started
-## Using the global logger
+Then in code, either import with the default name:
 ```rust
-use logging;
+use lambda_rs_logging as logging;
+```
+or, if you used the rename in Cargo.toml (Option B), simply:
+```rust
+use logging; // renamed in Cargo.toml
+```
+
+## Getting Started
+### Global logger via macros
+```rust
+use lambda_rs_logging as logging;
 
 fn main() {
-  logging::trace!("Hello world");
-  logging::debug!("Hello world");
-  logging::info!("Hello world");
-  logging::warn!("Hello world");
-  logging::error!("Hello world");
-  logging::fatal!("Hello world");
+  logging::trace!("trace {}", 1);
+  logging::debug!("debug {}", 2);
+  logging::info!("info {}", 3);
+  logging::warn!("warn {}", 4);
+  logging::error!("error {}", 5);
+  logging::fatal!("fatal {}", 6); // note: does not exit
 }
 ```
 
-## Using an instance of the logger
+### Custom logger instance
 ```rust
-use logging::Logger;
+use lambda_rs_logging as logging;
 
 fn main() {
-  let logger = Logger::new("my-logger");
-  logger.trace("Hello world");
-  logger.debug("Hello world");
-  logger.info("Hello world");
-  logger.warn("Hello world");
-  logger.error("Hello world");
-  logger.fatal("Hello world");
+  let logger = logging::Logger::new(logging::LogLevel::INFO, "my-app");
+  logger.add_handler(Box::new(logging::handler::ConsoleHandler::new("my-app")));
+
+  logger.info("Hello world".to_string());
+  logger.warn("Be careful".to_string());
 }
+```
+
+### Initialize a custom global
+```rust
+use lambda_rs_logging as logging;
+
+fn main() {
+  let logger = logging::Logger::new(logging::LogLevel::DEBUG, "app");
+  logger.add_handler(Box::new(logging::handler::ConsoleHandler::new("app")));
+
+  // Set the global logger before any macros are used
+  logging::Logger::init(logger).expect("global logger can only be initialized once");
+
+  logging::debug!("from global");
+}
+```
+
+## Notes
+- Thread-safe global with `OnceLock<Arc<Logger>>`.
+- Handlers are `Send + Sync` and receive a `Record` internally (phase 1 refactor).
+- `fatal!` logs at FATAL level but does not exit the process. Prefer explicit exits in your app logic.
+
+## Examples
+This crate ships with examples. From the repository root:
+```bash
+cargo run -p lambda-rs-logging --example 01_global_macros
+cargo run -p lambda-rs-logging --example 02_custom_logger
+cargo run -p lambda-rs-logging --example 03_global_init
 ```

--- a/crates/lambda-rs-logging/examples/01_global_macros.rs
+++ b/crates/lambda-rs-logging/examples/01_global_macros.rs
@@ -1,0 +1,8 @@
+fn main() {
+  logging::trace!("trace example");
+  logging::debug!("debug example: {}", 42);
+  logging::info!("info example");
+  logging::warn!("warn example");
+  logging::error!("error example");
+  logging::fatal!("fatal example (no exit)");
+}

--- a/crates/lambda-rs-logging/examples/02_custom_logger.rs
+++ b/crates/lambda-rs-logging/examples/02_custom_logger.rs
@@ -1,0 +1,8 @@
+fn main() {
+  let logger = logging::Logger::new(logging::LogLevel::DEBUG, "custom");
+  logger.add_handler(Box::new(logging::handler::ConsoleHandler::new("custom")));
+
+  logger.trace("this will be filtered unless level <= TRACE".to_string());
+  logger.debug("debug from custom logger".to_string());
+  logger.info("info from custom logger".to_string());
+}

--- a/crates/lambda-rs-logging/examples/03_global_init.rs
+++ b/crates/lambda-rs-logging/examples/03_global_init.rs
@@ -1,0 +1,9 @@
+fn main() {
+  let logger = logging::Logger::new(logging::LogLevel::INFO, "app");
+  logger.add_handler(Box::new(logging::handler::ConsoleHandler::new("app")));
+
+  logging::Logger::init(logger)
+    .expect("global logger can only be initialized once");
+
+  logging::info!("hello from initialized global");
+}

--- a/crates/lambda-rs-logging/examples/04_builder_env.rs
+++ b/crates/lambda-rs-logging/examples/04_builder_env.rs
@@ -1,6 +1,4 @@
-// When building examples inside the crate, the library is available as `logging`.
-// If you copy this example to another crate, import with `use lambda_rs_logging as logging;`
-use logging;
+// When building examples inside the crate, refer to the library as `logging` directly.
 
 fn main() {
   // Build a custom logger and apply env level

--- a/crates/lambda-rs-logging/examples/04_builder_env.rs
+++ b/crates/lambda-rs-logging/examples/04_builder_env.rs
@@ -1,0 +1,19 @@
+// When building examples inside the crate, the library is available as `logging`.
+// If you copy this example to another crate, import with `use lambda_rs_logging as logging;`
+use logging;
+
+fn main() {
+  // Build a custom logger and apply env level
+  let logger = logging::Logger::builder()
+    .name("builder-env")
+    .level(logging::LogLevel::INFO)
+    .with_handler(Box::new(logging::handler::ConsoleHandler::new(
+      "builder-env",
+    )))
+    .build();
+
+  logging::env::apply_env_level(&logger, Some("LAMBDA_LOG"));
+
+  logger.debug("filtered unless LAMBDA_LOG=debug".to_string());
+  logger.info("visible at info".to_string());
+}

--- a/crates/lambda-rs-logging/examples/05_json_handler.rs
+++ b/crates/lambda-rs-logging/examples/05_json_handler.rs
@@ -1,0 +1,17 @@
+// Inside this crate, refer to the lib as `logging` directly.
+
+fn main() {
+  let path = std::env::temp_dir().join("lambda_json_example.log");
+  let path_s = path.to_string_lossy().to_string();
+
+  let logger = logging::Logger::builder()
+    .name("json-example")
+    .level(logging::LogLevel::TRACE)
+    .with_handler(Box::new(logging::handler::JsonHandler::new(path_s.clone())))
+    .build();
+
+  logger.info("json info".to_string());
+  logger.error("json error".to_string());
+
+  println!("wrote JSON to {}", path_s);
+}

--- a/crates/lambda-rs-logging/examples/06_rotating_file.rs
+++ b/crates/lambda-rs-logging/examples/06_rotating_file.rs
@@ -1,0 +1,20 @@
+fn main() {
+  let base = std::env::temp_dir().join("lambda_rotate_example.log");
+  let base_s = base.to_string_lossy().to_string();
+
+  let logger = logging::Logger::builder()
+    .name("rotate-example")
+    .level(logging::LogLevel::TRACE)
+    .with_handler(Box::new(logging::handler::RotatingFileHandler::new(
+      base_s.clone(),
+      256, // bytes
+      3,   // keep 3 backups
+    )))
+    .build();
+
+  for i in 0..200 {
+    logger.info(format!("log line {:03}", i));
+  }
+
+  println!("rotation base: {} (check .1, .2, .3)", base_s);
+}

--- a/crates/lambda-rs-logging/src/lib.rs
+++ b/crates/lambda-rs-logging/src/lib.rs
@@ -1,7 +1,18 @@
 #![allow(clippy::needless_return)]
 //! A simple logging library for lambda-rs crates.
 
-use std::fmt::Debug;
+use std::{
+  sync::{
+    atomic::{
+      AtomicU8,
+      Ordering,
+    },
+    Arc,
+    OnceLock,
+    RwLock,
+  },
+  time::SystemTime,
+};
 
 /// A trait for handling log messages.
 pub mod handler;
@@ -17,11 +28,36 @@ pub enum LogLevel {
   FATAL,
 }
 
+impl LogLevel {
+  fn to_u8(self) -> u8 {
+    match self {
+      LogLevel::TRACE => 0,
+      LogLevel::DEBUG => 1,
+      LogLevel::INFO => 2,
+      LogLevel::WARN => 3,
+      LogLevel::ERROR => 4,
+      LogLevel::FATAL => 5,
+    }
+  }
+}
+
+/// A log record passed to handlers.
+#[derive(Debug, Clone)]
+pub struct Record<'a> {
+  pub timestamp: SystemTime,
+  pub level: LogLevel,
+  pub target: &'a str,
+  pub message: &'a str,
+  pub module_path: Option<&'static str>,
+  pub file: Option<&'static str>,
+  pub line: Option<u32>,
+}
+
 /// Logger implementation.
 pub struct Logger {
   name: String,
-  level: LogLevel,
-  handlers: Vec<Box<dyn handler::Handler>>,
+  level: AtomicU8,
+  handlers: RwLock<Vec<Box<dyn handler::Handler>>>,
 }
 
 impl Logger {
@@ -29,106 +65,102 @@ impl Logger {
   pub fn new(level: LogLevel, name: &str) -> Self {
     Self {
       name: name.to_string(),
-      level,
-      handlers: Vec::new(),
+      level: AtomicU8::new(level.to_u8()),
+      handlers: RwLock::new(Vec::new()),
     }
   }
 
-  /// Returns the global logger.
-  pub fn global() -> &'static mut Self {
-    // TODO(vmarcella): Fix the instantiation for the global logger.
-    unsafe {
-      if LOGGER.is_none() {
-        LOGGER = Some(Logger {
-          level: LogLevel::TRACE,
-          name: "lambda-rs".to_string(),
-          handlers: vec![Box::new(handler::ConsoleHandler::new("lambda-rs"))],
-        });
-      }
-    };
-    return unsafe { &mut LOGGER }
-      .as_mut()
-      .expect("Logger not initialized");
+  /// Returns the global logger (thread-safe). Initializes with a default
+  /// console handler if not explicitly initialized via `init`.
+  pub fn global() -> &'static Arc<Self> {
+    static GLOBAL: OnceLock<Arc<Logger>> = OnceLock::new();
+    GLOBAL.get_or_init(|| {
+      let logger = Logger::new(LogLevel::TRACE, "lambda-rs");
+      // Default console handler
+      logger.add_handler(Box::new(handler::ConsoleHandler::new("lambda-rs")));
+      Arc::new(logger)
+    })
+  }
+
+  /// Initialize the global logger (first caller wins).
+  pub fn init(logger: Logger) -> Result<(), InitError> {
+    static GLOBAL: OnceLock<Arc<Logger>> = OnceLock::new();
+    GLOBAL
+      .set(Arc::new(logger))
+      .map_err(|_| InitError::AlreadyInitialized)
   }
 
   /// Adds a handler to the logger. Handlers are called in the order they
   /// are added.
-  pub fn add_handler(&mut self, handler: Box<dyn handler::Handler>) {
-    self.handlers.push(handler);
+  pub fn add_handler(&self, handler: Box<dyn handler::Handler>) {
+    let mut lock = self.handlers.write().expect("poisoned handlers lock");
+    lock.push(handler);
+  }
+
+  /// Updates the minimum level for this logger.
+  pub fn set_level(&self, level: LogLevel) {
+    self.level.store(level.to_u8(), Ordering::Relaxed);
   }
 
   fn compare_levels(&self, level: LogLevel) -> bool {
-    level as u8 >= self.level as u8
+    level.to_u8() >= self.level.load(Ordering::Relaxed)
   }
 
-  /// Logs a trace message to all handlers.
-  pub fn trace(&mut self, message: String) {
-    if !self.compare_levels(LogLevel::TRACE) {
+  fn log_inner(&self, level: LogLevel, message: &str) {
+    if !self.compare_levels(level) {
       return;
     }
-
-    for handler in self.handlers.iter_mut() {
-      handler.trace(message.clone());
-    }
-  }
-
-  /// Logs a debug message to all handlers.
-  pub fn debug(&mut self, message: String) {
-    if !self.compare_levels(LogLevel::DEBUG) {
-      return;
-    }
-    for handler in self.handlers.iter_mut() {
-      handler.debug(message.clone());
-    }
-  }
-
-  /// Logs an info message to all handlers.
-  pub fn info(&mut self, message: String) {
-    if !self.compare_levels(LogLevel::INFO) {
-      return;
-    }
-
-    for handler in self.handlers.iter_mut() {
-      handler.info(message.clone());
+    let record = Record {
+      timestamp: SystemTime::now(),
+      level,
+      target: &self.name,
+      message,
+      module_path: None,
+      file: None,
+      line: None,
+    };
+    let lock = self.handlers.read().expect("poisoned handlers lock");
+    for handler in lock.iter() {
+      handler.log(&record);
     }
   }
 
-  /// Logs a warning to all handlers.
-  pub fn warn(&mut self, message: String) {
-    if !self.compare_levels(LogLevel::WARN) {
-      return;
-    }
-    for handler in self.handlers.iter_mut() {
-      handler.warn(message.clone());
-    }
+  /// Logs a trace message to all handlers (shim for backward compatibility).
+  pub fn trace(&self, message: String) {
+    self.log_inner(LogLevel::TRACE, &message);
   }
 
-  /// Logs an error to all handlers.
-  pub fn error(&mut self, message: String) {
-    if !self.compare_levels(LogLevel::ERROR) {
-      return;
-    }
-
-    for handler in self.handlers.iter_mut() {
-      handler.error(message.clone());
-    }
+  /// Logs a debug message to all handlers (shim for backward compatibility).
+  pub fn debug(&self, message: String) {
+    self.log_inner(LogLevel::DEBUG, &message);
   }
 
-  ///  Logs a fatal error to all handlers and exits the program.
-  pub fn fatal(&mut self, message: String) {
-    if !self.compare_levels(LogLevel::FATAL) {
-      return;
-    }
+  /// Logs an info message to all handlers (shim for backward compatibility).
+  pub fn info(&self, message: String) {
+    self.log_inner(LogLevel::INFO, &message);
+  }
 
-    for handler in self.handlers.iter_mut() {
-      handler.fatal(message.clone());
-    }
-    std::process::exit(1);
+  /// Logs a warning to all handlers (shim for backward compatibility).
+  pub fn warn(&self, message: String) {
+    self.log_inner(LogLevel::WARN, &message);
+  }
+
+  /// Logs an error to all handlers (shim for backward compatibility).
+  pub fn error(&self, message: String) {
+    self.log_inner(LogLevel::ERROR, &message);
+  }
+
+  /// Logs a fatal error to all handlers. Does NOT exit the process.
+  pub fn fatal(&self, message: String) {
+    self.log_inner(LogLevel::FATAL, &message);
   }
 }
 
-pub(crate) static mut LOGGER: Option<Logger> = None;
-
+/// Initialization error for the global logger.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitError {
+  AlreadyInitialized,
+}
 /// Trace logging macro using the global logger instance.
 #[macro_export]
 macro_rules! trace {
@@ -173,4 +205,155 @@ macro_rules! fatal {
   ($($arg:tt)*) => {
       logging::Logger::global().fatal(format!("{}", format_args!($($arg)*)));
   };
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{
+    sync::{
+      Arc,
+      Mutex,
+    },
+    thread,
+  };
+
+  use super::*;
+
+  #[derive(Default)]
+  struct TestHandler {
+    out: Arc<Mutex<Vec<(LogLevel, String)>>>,
+  }
+
+  impl TestHandler {
+    fn new(out: Arc<Mutex<Vec<(LogLevel, String)>>>) -> Self {
+      Self { out }
+    }
+  }
+
+  impl handler::Handler for TestHandler {
+    fn log(&self, record: &Record) {
+      self
+        .out
+        .lock()
+        .unwrap()
+        .push((record.level, record.message.to_string()));
+    }
+  }
+
+  #[test]
+  fn global_singleton_is_stable() {
+    let a = Logger::global().clone();
+    let b = Logger::global().clone();
+    assert!(Arc::ptr_eq(&a, &b));
+  }
+
+  #[test]
+  fn level_filtering_works() {
+    let logger = Logger::new(LogLevel::INFO, "test");
+    let out = Arc::new(Mutex::new(Vec::new()));
+    logger.add_handler(Box::new(TestHandler::new(out.clone())));
+
+    logger.debug("ignored".to_string());
+    logger.info("shown".to_string());
+
+    let recs = out.lock().unwrap();
+    assert_eq!(recs.len(), 1);
+    assert_eq!(recs[0].0, LogLevel::INFO);
+    assert_eq!(recs[0].1, "shown");
+  }
+
+  #[test]
+  fn handler_order_is_preserved_single_thread() {
+    #[derive(Default)]
+    struct TagHandler {
+      tag: &'static str,
+      out: Arc<Mutex<Vec<&'static str>>>,
+    }
+    impl handler::Handler for TagHandler {
+      fn log(&self, _record: &Record) {
+        self.out.lock().unwrap().push(self.tag);
+      }
+    }
+
+    let logger = Logger::new(LogLevel::TRACE, "order");
+    let out = Arc::new(Mutex::new(Vec::new()));
+    logger.add_handler(Box::new(TagHandler {
+      tag: "A",
+      out: out.clone(),
+    }));
+    logger.add_handler(Box::new(TagHandler {
+      tag: "B",
+      out: out.clone(),
+    }));
+
+    logger.info("x".to_string());
+
+    let v = out.lock().unwrap().clone();
+    assert_eq!(v, vec!["A", "B"]);
+  }
+
+  #[test]
+  fn concurrent_logging_no_panic_and_counts_match() {
+    let logger = Arc::new(Logger::new(LogLevel::TRACE, "concurrent"));
+    let out = Arc::new(Mutex::new(Vec::new()));
+    logger.add_handler(Box::new(TestHandler::new(out.clone())));
+
+    let mut handles = Vec::new();
+    for i in 0..8 {
+      let lg = logger.clone();
+      handles.push(thread::spawn(move || {
+        for j in 0..100 {
+          lg.debug(format!("msg {}:{}", i, j));
+        }
+      }));
+    }
+    for t in handles {
+      t.join().unwrap();
+    }
+
+    let recs = out.lock().unwrap();
+    assert_eq!(recs.len(), 800);
+  }
+
+  #[test]
+  fn fatal_does_not_exit() {
+    let logger = Logger::new(LogLevel::TRACE, "fatal");
+    let out = Arc::new(Mutex::new(Vec::new()));
+    logger.add_handler(Box::new(TestHandler::new(out.clone())));
+    logger.fatal("boom".to_string());
+    let recs = out.lock().unwrap();
+    assert_eq!(recs.len(), 1);
+    assert_eq!(recs[0].0, LogLevel::FATAL);
+    assert_eq!(recs[0].1, "boom");
+  }
+
+  #[test]
+  fn file_handler_flushes_after_ten() {
+    use std::{
+      fs,
+      time::UNIX_EPOCH,
+    };
+
+    let tmp = std::env::temp_dir().join(format!(
+      "lambda_logging_test_{}_{}.log",
+      std::process::id(),
+      SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+    ));
+
+    let logger = Logger::new(LogLevel::TRACE, "file");
+    logger.add_handler(Box::new(crate::handler::FileHandler::new(
+      tmp.to_string_lossy().to_string(),
+    )));
+
+    for i in 0..10 {
+      logger.info(format!("line{}", i));
+    }
+
+    let content =
+      fs::read_to_string(&tmp).expect("file must exist after flush");
+    assert!(!content.is_empty());
+  }
 }

--- a/docs/logging-guide.md
+++ b/docs/logging-guide.md
@@ -1,0 +1,78 @@
+---
+title: "Lambda RS Logging Guide"
+document_id: "logging-guide-2025-09-28"
+status: "living"
+created: "2025-09-28T21:17:44Z"
+last_updated: "2025-09-28T21:17:44Z"
+version: "0.2.0"
+engine_workspace_version: "2023.1.30"
+wgpu_version: "26.0.1"
+shader_backend_default: "naga"
+winit_version: "0.29.10"
+repo_commit: "637b82305833ef0db6079bcae5f64777e847a505"
+owners: ["lambda-sh"]
+reviewers: ["engine", "rendering"]
+tags: ["guide", "logging", "engine", "infra"]
+---
+
+Summary
+- Thread-safe logging crate with global and instance loggers.
+- Minimal-overhead macros, configurable level, and pluggable handlers.
+- Console, file, JSON, and rotating-file handlers included.
+
+Quick Start
+- Global macros:
+  - Add dependency (rename optional): `logging = { package = "lambda-rs-logging", version = "2023.1.30" }`
+  - Use: `logging::info!("hello {}", 123);`
+- Custom global from env:
+  - `logging::env::init_global_from_env().ok(); // honors LAMBDA_LOG`
+- Custom logger:
+  - `let logger = logging::Logger::builder().name("app").level(logging::LogLevel::INFO).with_handler(Box::new(logging::handler::ConsoleHandler::new("app"))).build();`
+
+Core Concepts
+- Level filtering: `TRACE < DEBUG < INFO < WARN < ERROR < FATAL`.
+- Early guard: macros check level before formatting message.
+- Handlers: `Send + Sync` sinks implementing `fn log(&self, record: &Record)`.
+- Record fields: timestamp, level, target(name), message, module/file/line.
+
+Configuration
+- Global init:
+  - Default global created on first use (`TRACE`, console handler).
+  - Override once via `Logger::init(logger)`.
+- Builder:
+  - `Logger::builder().name(..).level(..).with_handler(..).build()`.
+- Environment:
+  - `LAMBDA_LOG=trace|debug|info|warn|error|fatal`.
+  - `logging::env::apply_env_level(&logger, Some("LAMBDA_LOG"));`
+  - `logging::env::init_global_from_env()` creates a console logger and applies env.
+
+Handlers
+- ConsoleHandler
+  - Colors only when stdout/stderr are TTYs.
+  - Writes WARN/ERROR/FATAL to stderr; TRACE/DEBUG/INFO to stdout.
+- FileHandler
+  - Appends colored lines to a file (legacy behavior). Flushes every 10 messages.
+- JsonHandler
+  - Newline-delimited JSON (one object per line). Minimal string escaping.
+  - Use: `with_handler(Box::new(logging::handler::JsonHandler::new("/path/log.jsonl".into())))`.
+- RotatingFileHandler
+  - Rotates when current file exceeds `max_bytes`.
+  - Keeps `backups` files as `file.1`, `file.2`, ...
+  - Use: `RotatingFileHandler::new("/path/app.log".into(), 1_048_576, 3)`.
+
+Macros
+- `trace!/debug!/info!/warn!/error!/fatal!`
+  - Use `$crate` and `format_args!` internally for low overhead when disabled.
+  - Attach module/file/line to records for handler formatting.
+
+Examples (run from repo root)
+- `cargo run -p lambda-rs-logging --example 01_global_macros`
+- `cargo run -p lambda-rs-logging --example 02_custom_logger`
+- `cargo run -p lambda-rs-logging --example 03_global_init`
+- `cargo run -p lambda-rs-logging --example 04_builder_env`
+- `cargo run -p lambda-rs-logging --example 05_json_handler`
+- `cargo run -p lambda-rs-logging --example 06_rotating_file`
+
+Changelog
+- 0.2.0: Added builder, env config, JSON and rotating file handlers; improved console (colors on TTY, WARN+ to stderr); macro early-guard.
+- 0.1.0: Initial spec and thread-safe global with unified handler API.

--- a/docs/logging-improvements-spec.md
+++ b/docs/logging-improvements-spec.md
@@ -1,0 +1,133 @@
+---
+title: "lambda-rs Logging: Design Review and Improvement Spec"
+document_id: "logging-spec-2025-09-28"
+status: "draft"
+created: "2025-09-28T05:35:01Z"
+last_updated: "2025-09-28T05:35:01Z"
+version: "0.1.0"
+engine_workspace_version: "2023.1.30"
+wgpu_version: "26.0.1"
+shader_backend_default: "naga"
+winit_version: "0.29.10"
+repo_commit: "964d58c0658a4c5d23a4cf33f4a8ecc12458dad6"
+owners: ["lambda-sh"]
+reviewers: ["engine", "rendering"]
+tags: ["spec", "logging", "engine", "infra"]
+---
+
+**Summary**
+- Evaluate current `lambda-rs-logging` design and implementation.
+- Propose a thread-safe, low-overhead, extensible logging API with clear migration.
+
+**Goals**
+- Thread-safe global and instance loggers without `unsafe`.
+- Low allocation and minimal formatting when disabled.
+- Simple API for console/file; room for structured output.
+- Clear configuration (builder + env vars) and sane defaults.
+- Compatibility bridge with the broader Rust ecosystem (`log`/`tracing`).
+
+**Current State**
+- Files: `crates/lambda-rs-logging/src/lib.rs`, `crates/lambda-rs-logging/src/handler.rs`.
+- API: `Logger { name, level, handlers }` with per-level methods that take `&mut self` and `String`.
+- Global: `pub(crate) static mut LOGGER: Option<Logger>` initialized in `Logger::global()` via `unsafe`.
+- Handlers: `ConsoleHandler`, `FileHandler`; both colorize; file buffers 10 messages then writes.
+- Macros: `trace!/debug!/…` call `logging::Logger::global()` and eagerly `format!(...)`.
+
+**Key Issues**
+- Unsound global singleton
+  - `static mut` + `&'static mut` return is not thread-safe and is UB under concurrency.
+- Macro design and overhead
+  - Always allocates due to `format!` before level check; path uses `logging::` instead of `$crate`.
+- Concurrency and ergonomics
+  - `Logger` methods require `&mut self`; `Handler` requires `&mut self`, preventing concurrent logging; no `Send + Sync` guarantees.
+- Fatal behavior
+  - `Logger::fatal` calls `std::process::exit(1)` in a library crate; surprising and hard to test.
+- File handler
+  - Color codes in files; buffered writes with no `Drop` flush; potential data loss at shutdown; no newline guarantee.
+- Output streams
+  - All levels write to stdout; `WARN+` should prefer stderr.
+- Timestamps and format
+  - Seconds-since-epoch, not human-friendly; no timezone; no module/file/line metadata.
+- Documentation drift
+  - README example does not match API (`Logger::new` signature); crate/lib naming is confusing.
+
+**Proposed Design**
+
+- Core types
+  - `enum Level { Trace, Debug, Info, Warn, Error }` plus optional `Off`.
+  - `struct Record<'a> { ts: SystemTime, level: Level, target: &'a str, message: std::fmt::Arguments<'a>, module_path: Option<&'static str>, file: Option<&'static str>, line: Option<u32> }`.
+
+- Handler trait
+  - `pub trait Handler: Send + Sync { fn enabled(&self, level: Level, target: &str) -> bool { true } fn log(&self, record: &Record); }`
+  - Rationale: single entry point, shared across levels; concurrency via `&self` with interior mutability where needed.
+
+- Logger internals
+  - `pub struct Logger { name: String, level: AtomicLevel, handlers: RwLock<Vec<std::sync::Arc<dyn Handler>>> }`
+  - `AtomicLevel` is a thin wrapper over `AtomicU8` with `Level` conversions.
+  - `impl Logger` exposes `builder()`, `level()`, `set_level()`, `add_handler()`, `clear_handlers()`.
+
+- Global initialization
+  - `static LOGGER: std::sync::OnceLock<std::sync::Arc<Logger>>`.
+  - `pub fn init(logger: Logger) -> Result<(), InitError>`; first caller wins; no `unsafe`.
+  - `pub fn global() -> &'static std::sync::Arc<Logger>` returns initialized default (console info) if `init` not called.
+
+- Macros (zero/low-cost when disabled)
+  - Use `$crate` for paths and `format_args!` to avoid allocation:
+    - `macro_rules! log { ($lvl:expr, $($arg:tt)*) => {{ if $crate::enabled($lvl) { $crate::log_args($lvl, module_path!(), file!(), line!(), format_args!($($arg)*)); } }} }`
+    - Define `trace!/debug!/info!/warn!/error!` in terms of `log!`.
+  - Early guard using an atomic global level to skip work before formatting.
+
+- Console handler
+  - Color only when writing to a TTY (use `atty` or equivalent); write `WARN+` to `stderr`.
+  - Default format: `YYYY-MM-DDTHH:MM:SS.sssZ level target: message`.
+
+- File handler
+  - No color; use `BufWriter<File>` behind a `Mutex` to ensure thread-safety.
+  - Flush on newline or on `Drop`; optional size-based rotation later.
+
+- Configuration
+  - Builder: `Logger::builder().name("lambda-rs").level(Level::Info).with_handler(Arc<ConsoleHandler>::default()).build()`.
+  - Env var parser (opt-in): `LAMBDA_LOG="info,lambda_rs_render=debug"` to set per-target levels.
+  - Feature flags: `color` (default on), `env` (enable env parsing), `log-bridge`, `tracing-bridge`.
+
+- Ecosystem bridges (optional, but recommended)
+  - `log` facade: implement `log::Log` for a thin adapter that forwards to our `Logger`; provide `init_log_bridge()`.
+  - `tracing` bridge (future): implement a basic `tracing_subscriber::Layer` emitting to handlers.
+
+- API surface (sketch)
+  - `pub fn enabled(level: Level) -> bool`
+  - `pub fn log_args(level: Level, target: &str, file: &'static str, line: u32, args: Arguments)`
+  - `pub mod macros { pub use crate::{trace, debug, info, warn, error}; }`
+
+**Migration Plan**
+- Phase 1: Internals refactor (Record, Handler::log, OnceLock global); keep old methods/macros working via shims.
+- Phase 2: Macro rewrite with `$crate` and early guard; mark old `String`-based methods `#[deprecated]`.
+- Phase 3: Introduce builder and env config; update examples/README.
+- Phase 4: Optional bridges (`log` facade) and additional handlers (JSON, rotating file).
+
+**Backwards Compatibility**
+- Maintain `trace!/debug!/…` macro names; forward to new implementation.
+- Keep `Logger::{trace,debug,…}(String)` for one release, delegating to the new `Arguments`-based path; deprecate with guidance.
+- Remove `fatal` auto-exit; add `fatal_and_exit!` macro behind a `danger-exit` feature flag for explicit opt-in.
+
+**Testing**
+- Unit tests: level filtering, macro early-exit (no formatting when disabled), handler invocation order, builder config.
+- Concurrency tests: multi-threaded logging to console/file without panics or data races.
+- Integration tests: env var parsing; bridge to `log` (if feature enabled).
+- Snapshot tests for formatted output (normalize timestamps via injection).
+
+**Documentation Updates**
+- Fix README examples to match signatures and import paths; clarify crate name vs lib name.
+- Add a usage guide with builder, env config, and handler customization.
+- Document migration notes and deprecations.
+
+**Risks & Trade-offs**
+- Adding `OnceLock`, `RwLock`, and atomics slightly increases complexity but removes UB and makes logging robust under concurrency.
+- Bridging to `log`/`tracing` introduces optional deps; gate behind features to keep core lightweight.
+
+**Open Questions**
+- Do we want hierarchical targets (e.g., `engine.render` inheritance) in v1, or keep flat target-level map?
+- Should we default to integrating with `log` to reduce duplicate macros across crates?
+
+**Changelog**
+- 0.1.0 (draft): Initial spec, proposes thread-safe global, unified handler API, macro rewrite, configuration, and ecosystem bridges.


### PR DESCRIPTION
  - Replace unsound static mut global with OnceLock<Arc<Logger>>; Logger::global() now thread-safe
  - Unify handler API: pub trait Handler: Send + Sync { fn log(&self, record: &Record) }
  - Introduce Record (timestamp, level, target, message, module/file/line) passed to handlers
  - Make Logger concurrent: AtomicU8 for level; RwLock<Vec<Box<dyn Handler>>> for handlers; methods
  take &self
  - Remove implicit process exit from fatal; it now only logs (explicit exit left to the app)
  - Add low-overhead logging helpers: enabled(level) and log_args(level, module, file, line, args)
  - Rewrite macros (trace!/debug!/info!/warn!/error!/fatal!) to use $crate, early level guard, and
  format_args! with metadata
  - Improve ConsoleHandler: color only when attached to a TTY; write WARN/ERROR/FATAL to stderr,
  others to stdout
  - Keep FileHandler behavior but make it thread-safe (buffer protected by Mutex; flush every 10
  messages)
  - Add Logger::builder() API (name, level, .with_handler(...)) for ergonomic configuration
  - Add environment config module:
      - env::parse_level(&str) -> Option<LogLevel>
      - env::apply_env_level(&Logger, Option<&str>) (defaults to LAMBDA_LOG)
      - env::init_global_from_env() to create a global console logger honoring LAMBDA_LOG
  - Add JsonHandler (newline-delimited JSON) and RotatingFileHandler (size-based rotation with
  backups)
  - Update README with new usage (builder, env config, console behavior) and clarify import options
  - Add comprehensive logging guide: docs/logging-guide.md (overview, config, handlers, examples,
  changelog)
  - Add improvement spec doc: docs/logging-improvements-spec.md with metadata and phased plan
  - Add runnable examples:
      - 01_global_macros.rs (macros)
      - 02_custom_logger.rs (custom instance)
      - 03_global_init.rs (init custom global)
      - 04_builder_env.rs (builder + env level)
      - 05_json_handler.rs (JSON output)
      - 06_rotating_file.rs (size-based rotation)
  - Add tests covering:
      - Global singleton identity; level filtering; handler order; multi-threaded logging
      - fatal behavior (no exit); macro early-guard (no formatting when disabled)
      - Builder config; env parse/apply; JSON write; rotation behavior
  - Verified locally:
      - cargo test (workspace): all pass
      - cargo clippy -p lambda-rs-logging --all-targets -- -D warnings: clean
      - cargo build -p lambda-rs-logging --examples: builds all examples
  - Breaking changes:
      - Handler implementations must migrate to fn log(&self, &Record)
      - fatal! no longer exits (apps should exit explicitly if desired)
